### PR TITLE
archiverで4つ以上のリポジトリを保存すると最後に保存したリポジトリのtodos以外がnullになるバグのためtod…

### DIFF
--- a/GitOdo/GitOdo/ArchiveConnection.swift
+++ b/GitOdo/GitOdo/ArchiveConnection.swift
@@ -194,10 +194,11 @@ class ArchiveConnection: NSObject {
   }
   
   func unarchiveTodos () -> [RepositoryObject: [protocol<ToDoObjectProtocol>]] {
-    let archivedOrNil: AnyObject? = NSKeyedUnarchiver.unarchiveObjectWithFile(Directory.todos)
-    if let archived = archivedOrNil as? [RepositoryObject: [protocol<ToDoObjectProtocol>]] {
-      return archived
-    }
+//    let archivedOrNil: AnyObject? = NSKeyedUnarchiver.unarchiveObjectWithFile(Directory.todos)
+//    print(archivedOrNil)
+//    if let archived = archivedOrNil as? [RepositoryObject: [protocol<ToDoObjectProtocol>]] {
+//      return archived
+//    }
     return [:]
   }
 }


### PR DESCRIPTION
…osのキャッシュ機能を一旦削除
